### PR TITLE
Hotfix/create definition bytestring

### DIFF
--- a/datasift/__init__.py
+++ b/datasift/__init__.py
@@ -245,7 +245,9 @@ class Definition:
         if csdl == False:
             self._csdl = False
         else:
-            if not isinstance(csdl, str):
+            if isinstance(csdl, unicode):
+                csdl = csdl.encode('utf8')
+            elif not isinstance(csdl, str):
                 raise InvalidDataError('Definitions must be strings.')
 
             csdl = csdl.strip()

--- a/tests/test_user.py
+++ b/tests/test_user.py
@@ -24,6 +24,11 @@ class TestUser(unittest.TestCase):
         self.assertIsInstance(definition, datasift.Definition, 'Failed to create an empty definition')
         self.assertEqual(definition.get(), '', 'Definition is not empty')
 
+    def test_create_definition_unicode(self):
+        definition = self.user.create_definition(testdata.unicode_definition)
+        self.assertIsInstance(definition, datasift.Definition, 'Failed to create a non-empty definition')
+        self.assertEqual(definition.get(), testdata.definition, 'Definition is incorrect')
+
     def test_create_definition_nonempty(self):
         definition = self.user.create_definition(testdata.definition)
         self.assertIsInstance(definition, datasift.Definition, 'Failed to create a non-empty definition')

--- a/tests/testdata.py
+++ b/tests/testdata.py
@@ -4,6 +4,8 @@ api_key = 'my_api_key'
 definition = 'interaction.content contains "datasift"'
 definition_hash = '947b690ec9dca525fb8724645e088d79'
 
+unicode_definition = u'interaction.content contains "datasift"'
+
 invalid_definition = 'interactin.content contains "datasift"'
 
 stream_id = 10121


### PR DESCRIPTION
Allow applications to pass unicode CSDL strings to the datasift client, which will encode to UTF8 if needed.
