### PR TITLE
Build the python-datasift package using Travis-CI.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: python
 python:
-  - "2.4"
   - "2.5"
   - "2.6"
   - "2.7"


### PR DESCRIPTION
This patch set (#35) and the [**bug/old_python_versions**](https://github.com/datasift/datasift-python/pull/36) patch set (#36) are related; with this patch the Travis-CI builds will fail on Python 2.5 and Python 2.6 as the the module will not build on Python 2.5 and the tests will not run on Python 2.5/2.6. The patch set #36 fixes the issues with building on Python 2.5 and running the tests under Python 2.5/2.6. 
As is stands this patch set will result is a broken build on Travis-CI, if an automated build setup using Travis-CI is desirable then an additional patch (9a028d275330886f5c2e0a6ebec6437dd8f3018a) would have to be made to this patch set to include the two extra dependencies introduced in #36. 
