### PR TITLE
Only try to stop the consumer thread once on error

### DIFF
--- a/datasift/__init__.py
+++ b/datasift/__init__.py
@@ -1514,7 +1514,6 @@ class StreamConsumer(object):
                 # Status notification
                 if data['status'] == 'failure' or data['status'] == 'error':
                     self._on_error(data['message'])
-                    self.stop()
                 elif data['status'] == 'warning':
                     self._on_warning(data['message'])
                 else:


### PR DESCRIPTION
Thread is already stopped by _on_error, fixes InvalidDataError on disconnect
and other errors.
