### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -4,7 +4,7 @@ DataSift Python Client Library
 .. image:: https://travis-ci.org/datasift/datasift-python.svg?branch=master
     :target: https://travis-ci.org/datasift/datasift-python.svg?branch=master
 
-.. image:: https://pypip.in/v/datasift/badge.png
+.. image:: https://img.shields.io/pypi/v/datasift.svg
     :target: https://pypi.python.org/pypi/datasift
 
 This is the official Python library for accessing DataSift APIs.


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20datasift-beta))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `datasift-beta`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badge to use shields.io instead.